### PR TITLE
Remove the mesa-libgl dependency

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -70,7 +70,6 @@ makedepends=(autoconf ncurses bison perl fontforge flex
   alsa-lib              lib32-alsa-lib
   libxcomposite         lib32-libxcomposite
   mesa                  lib32-mesa
-  mesa-libgl            lib32-mesa-libgl
   opencl-icd-loader     lib32-opencl-icd-loader
   libxslt               lib32-libxslt
   libpulse              lib32-libpulse


### PR DESCRIPTION
already implied with mesa, the wine-git pkgbuild does not have it either.