### PR TITLE
Add pkgconf as a build dependency

### DIFF
--- a/wine-lol/PKGBUILD
+++ b/wine-lol/PKGBUILD
@@ -90,6 +90,7 @@ makedepends=(autoconf ncurses bison perl fontforge flex
   ffmpeg
   samba
   opencl-headers
+  pkgconf
 )
 
 optdepends=(


### PR DESCRIPTION
As it may strange, I accidentally remove `pkgconf` from my system, ending up with Wine build errors like :

```
configure:14948: checking ft2build.h usability
configure:14948: gcc -m32 -c -m32 -march=x86-64 -mtune=generic -O2 -pipe  -fcommon -D_FORTIFY_SOURCE=2  conftest.c >&5
conftest.c:219:10: fatal error: ft2build.h: No such file or directory
  219 | #include <ft2build.h>
      |          ^~~~~~~~~~~~
compilation terminated.
```

Indeed `ft2build.h` is in `/usr/include/freetype2`, and the configure script of Wine have these lines :

```bash
if ${PKG_CONFIG+:} false; then :
  FREETYPE_CFLAGS=`$PKG_CONFIG --cflags freetype2 2>/dev/null`
fi
```

And `/usr/lib32/pkgconfig/freetype2.pc` has an additional include path for `freetype2` : `Cflags: -I${includedir}/freetype2`. 

I don't really know Arch packaging but it may help to add `pkgconf` as a build dependency to avoid this kind of errors (even if it's kind of my fault in this case). 