### PR TITLE
fix(wine-lol): add pkgconf to makedepends

### DIFF
--- a/wine-lol/PKGBUILD
+++ b/wine-lol/PKGBUILD
@@ -60,7 +60,7 @@ depends=(
   wine-lol-glibc
 )
 
-makedepends=(autoconf ncurses bison perl fontforge flex
+makedepends=(autoconf pkgconf ncurses bison perl fontforge flex
   'gcc>=4.5.0-2'
   giflib                lib32-giflib
   libpng                lib32-libpng


### PR DESCRIPTION
I ran into an `autoconf` error about a missing `ft2build.h` when installing `wine-lol` with the latest `wine-lol-glibc`. Turns out it was due this missing `pkgconf` package.