### PR TITLE
Update to wine 5.16 (does not work!)

### DIFF
--- a/wine-lol/.SRCINFO
+++ b/wine-lol/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = wine-lol
 	pkgdesc = A compatibility layer for running Windows programs - Staging branch with League Of Legends fixes
-	pkgver = 5.6
+	pkgver = 5.16
 	pkgrel = 1
 	url = http://www.wine-staging.com
 	install = wine.install
@@ -149,16 +149,14 @@ pkgbase = wine-lol
 	optdepends = samba
 	optdepends = dosbox
 	options = staticlibs
-	source = https://dl.winehq.org/wine/source/5.x/wine-5.6.tar.xz
-	source = wine-staging-v5.6.tar.gz::https://github.com/wine-staging/wine-staging/archive/v5.6.tar.gz
-	source = https://raw.githubusercontent.com/wine-staging/wine-staging/8d4d0a840e6ce434483edd81acb3be90fd734e44/patches/user32-rawinput-mouse/0005-server-Broadcast-rawinput-message-if-request-flag-is.patch
+	source = https://dl.winehq.org/wine/source/5.x/wine-5.16.tar.xz
+	source = wine-staging-v5.16.tar.gz::https://github.com/wine-staging/wine-staging/archive/v5.16.tar.gz
 	source = 30-win32-aliases.conf
 	source = wine-lol-bug-47198-fix.patch
-	sha512sums = b12b0eff228ecd783fec8bf91f97e4387125226b172046d800e1fbffa303ceca32f1f647b9e8ceb24d303c23eb57188be14ddd8ba5fc04ba781a69186fbe6be4
-	sha512sums = 7ddf5699834a6e04b094a7cae008175c874415d22554bac38176f3121b9533071ef610f8b5a0dd3ce3e4adf8a9d4ac214aa1cee7634959c5150b66fbb74710b7
-	sha512sums = 13ce85885270990f8f2cf6c1f872fc855b3caf5bc1de01022caf0b05dd6957e55391cd8dcd15ff0cc18cf3035851a8289a2e12e17f2f50b626b68afd10e3f315
+	sha512sums = e198478bcf91106af82b37c87f42961a6c37aa80ea5cf05c268a36ba2ba73c23ac6864b183b927cf3c10d666d60b9f6877edccf7746eafe8968a36b5ce3740be
+	sha512sums = 62e103dd5b591bc1066b91299a95c318bf1588f273f8380c1ac43d5367b695055a1684b8cc6473255a0b449b21a483ff4e87adc3ae332d0fb520023340fff79f
 	sha512sums = 6e54ece7ec7022b3c9d94ad64bdf1017338da16c618966e8baf398e6f18f80f7b0576edf1d1da47ed77b96d577e4cbb2bb0156b0b11c183a0accf22654b0a2bb
-	sha512sums = a17db33ba5d6114bd71d1b013adc8e5ca0c3cedf856301cba59f95dadf643d2ee0e5a2d7abb2daedd5ed7c45cdbe93c78527f4d962bedc54776bb21cfc7e8b0b
+	sha512sums = b1f0096e9cdb660725aad620ac54b002979e73eeb4e36e4d0a4654a335f314399b960628cfd17f13398ffc65a6aca12d686d3e0317411af6e46283a5a5af425a
 
 pkgname = wine-lol
 

--- a/wine-lol/PKGBUILD
+++ b/wine-lol/PKGBUILD
@@ -12,26 +12,19 @@
 # Primary bug report: https://bugs.winehq.org/show_bug.cgi?id=47198
 
 pkgname=wine-lol
-# Note: We are forced to use Wine 5.6 until this bug is fixed:
-#       https://bugs.winehq.org/show_bug.cgi?id=49025
-pkgver=5.6
+pkgver=5.16
 pkgrel=1
 
 _pkgbasever=${pkgver/rc/-rc}
 
-# TODO: Remove 0005-server-Broadcast-rawinput-message-if-request-flag-is.patch
-#       here and in prepare() for wine >= 5.7
-#       Used to fix https://bugs.winehq.org/show_bug.cgi?id=48946
 source=(https://dl.winehq.org/wine/source/5.x/wine-$_pkgbasever.tar.xz
         "wine-staging-v$_pkgbasever.tar.gz::https://github.com/wine-staging/wine-staging/archive/v$_pkgbasever.tar.gz"
-        https://raw.githubusercontent.com/wine-staging/wine-staging/8d4d0a840e6ce434483edd81acb3be90fd734e44/patches/user32-rawinput-mouse/0005-server-Broadcast-rawinput-message-if-request-flag-is.patch
         30-win32-aliases.conf
         wine-lol-bug-47198-fix.patch)
-sha512sums=('b12b0eff228ecd783fec8bf91f97e4387125226b172046d800e1fbffa303ceca32f1f647b9e8ceb24d303c23eb57188be14ddd8ba5fc04ba781a69186fbe6be4'
-            '7ddf5699834a6e04b094a7cae008175c874415d22554bac38176f3121b9533071ef610f8b5a0dd3ce3e4adf8a9d4ac214aa1cee7634959c5150b66fbb74710b7'
-            '13ce85885270990f8f2cf6c1f872fc855b3caf5bc1de01022caf0b05dd6957e55391cd8dcd15ff0cc18cf3035851a8289a2e12e17f2f50b626b68afd10e3f315'
+sha512sums=('e198478bcf91106af82b37c87f42961a6c37aa80ea5cf05c268a36ba2ba73c23ac6864b183b927cf3c10d666d60b9f6877edccf7746eafe8968a36b5ce3740be'
+            '62e103dd5b591bc1066b91299a95c318bf1588f273f8380c1ac43d5367b695055a1684b8cc6473255a0b449b21a483ff4e87adc3ae332d0fb520023340fff79f'
             '6e54ece7ec7022b3c9d94ad64bdf1017338da16c618966e8baf398e6f18f80f7b0576edf1d1da47ed77b96d577e4cbb2bb0156b0b11c183a0accf22654b0a2bb'
-            'a17db33ba5d6114bd71d1b013adc8e5ca0c3cedf856301cba59f95dadf643d2ee0e5a2d7abb2daedd5ed7c45cdbe93c78527f4d962bedc54776bb21cfc7e8b0b')
+            'b1f0096e9cdb660725aad620ac54b002979e73eeb4e36e4d0a4654a335f314399b960628cfd17f13398ffc65a6aca12d686d3e0317411af6e46283a5a5af425a')
 
 pkgdesc="A compatibility layer for running Windows programs - Staging branch with League Of Legends fixes"
 url="http://www.wine-staging.com"
@@ -131,8 +124,6 @@ prepare() {
 
   # apply wine-staging patchset
   pushd wine-staging-$_pkgbasever/patches
-  # Place updated patch
-  cp "$srcdir/0005-server-Broadcast-rawinput-message-if-request-flag-is.patch" user32-rawinput-mouse
   ./patchinstall.sh DESTDIR="$srcdir/$pkgname" --all
   popd
 
@@ -153,9 +144,7 @@ build() {
   mkdir $pkgname-{32,64}-build
 
   # https://bugs.winehq.org/show_bug.cgi?id=43530
-  # TODO: Remove -fcommon for wine >= 5.8
-  #       Used to work around gcc 10.1 build issue
-  export CFLAGS="${CFLAGS/-fno-plt/} -fcommon"
+  export CFLAGS="${CFLAGS/-fno-plt/}"
   export LDFLAGS="${LDFLAGS/,-z,now/}"
 
   # We need RPATH to point to the "lib32" in our prefix

--- a/wine-lol/wine-lol-bug-47198-fix.patch
+++ b/wine-lol/wine-lol-bug-47198-fix.patch
@@ -1,19 +1,18 @@
-diff --git a/dlls/ntdll/thread.c b/dlls/ntdll/thread.c
-index c5b2008e44..96ca266921 100644
---- a/dlls/ntdll/thread.c
-+++ b/dlls/ntdll/thread.c
-@@ -268,6 +268,77 @@ static void set_process_name( int argc, char *argv[] )
+diff --git a/dlls/ntdll/unix/signal_i386.c b/dlls/ntdll/unix/signal_i386.c
+index fa4eec3..2007002 100644
+--- a/dlls/ntdll/unix/signal_i386.c
++++ b/dlls/ntdll/unix/signal_i386.c
+@@ -2363,6 +2363,73 @@ void signal_init_thread( TEB *teb )
  }
  
  
-+#ifdef __i386__
 +#include <asm/ldt.h>
 +#include <linux/audit.h>
 +#include <linux/filter.h>
 +#include <linux/seccomp.h>
 +#include <linux/unistd.h>
 +#include <sys/prctl.h>
-+#include <errno.h>
++#include <stdint.h>
 +
 +static void sigsys_handler( int signal, siginfo_t *siginfo, void *sigcontext )
 +{
@@ -26,8 +25,6 @@ index c5b2008e44..96ca266921 100644
 +    ctx->uc_mcontext.gregs[REG_EAX] = 0;
 +}
 +
-+// FIXME All of this code is i386 Linux-specific. It may want to live in
-+//       signal_i386.c.
 +void seccomp_init(void)
 +{
 +    int ret;
@@ -74,20 +71,16 @@ index c5b2008e44..96ca266921 100644
 +    //       assumes at least 0x6C bytes are reserved.
 +    *(uint64_t *)(tcbhead + 0x60) = (uintptr_t)(tcbhead + 0x68);
 +}
-+#endif
 +
 +
- /***********************************************************************
-  *           thread_init
-  *
-@@ -370,6 +441,10 @@ TEB *thread_init(void)
-     __wine_user_shared_data();
-     fill_cpu_info();
+ /**********************************************************************
+  *		signal_init_process
+  */
+@@ -2392,6 +2459,7 @@ void signal_init_process(void)
+     if (sigaction( SIGSEGV, &sig_act, NULL ) == -1) goto error;
+     if (sigaction( SIGILL, &sig_act, NULL ) == -1) goto error;
+     if (sigaction( SIGBUS, &sig_act, NULL ) == -1) goto error;
++    seccomp_init();
+     return;
  
-+#ifdef __i386__
-+   seccomp_init();
-+#endif
-+
-     return teb;
- }
- 
+  error:


### PR DESCRIPTION
thx for building this up. but i found out it won't work with valorant.
can you also do the same with a patched wine version that includes 64bit playing?
cause valorant won't work with 32 bit anymore.

it would i bet fix the whole playing issue with linux for the valorant game. 
if LOL works. valorant should also work pretending you make the missing 64bit version.
as i doubt there is more than just this issue.

thx in advance cr4sh