### PR TITLE
Fix wine-lol-glibc build flags

### DIFF
--- a/wine-lol-glibc/PKGBUILD
+++ b/wine-lol-glibc/PKGBUILD
@@ -66,8 +66,7 @@ build() {
   echo "rootsbindir=/opt/wine-lol/bin" >> configparms
 
   # remove fortify for building libraries
-  CPPFLAGS=${CPPFLAGS/-D_FORTIFY_SOURCE=2/} # Before and
-  CFLAGS=${CFLAGS/-D_FORTIFY_SOURCE=2,/} # after https://github.com/archlinux/svntogit-packages/commit/a790c38
+  CFLAGS=${CFLAGS/-Wp,-D_FORTIFY_SOURCE=2/}
   CFLAGS=${CFLAGS/-fno-plt/}
   CXXFLAGS=${CXXFLAGS/-fno-plt/}
 


### PR DESCRIPTION
Works with [current (pacman 6.0.0-2) default makepkg.conf](https://github.com/archlinux/svntogit-packages/blob/accc1d210133a933f2b26e0aad842c27d00c8b0c/trunk/makepkg.conf#L41)

The problem was that `D_FORTIFY_SOURCE=2` was not removed properly. The current default makepkg.conf specifies `CLAGS` as follows:
```bash
CFLAGS="-march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fexceptions \
        -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security \
        -fstack-clash-protection -fcf-protection"
```