### PR TITLE
Add Dockerfile to the repo which lets you build on **any** distro

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,60 @@
+# First we're gonna build glibc and then export it so we can proceed with wine
+#   # This lets us cache this process
+FROM archlinux:latest as glibc-builder
+# Dependencies for building packages with makepkg
+RUN pacman -Sy --noconfirm --needed sudo base-devel 
+# Dependencies for wine-lol-glibc
+RUN pacman -Sy --noconfirm --needed git gd lib32-gcc-libs python
+
+# copy source for glibc
+WORKDIR /wine-lol-glibc
+ADD wine-lol-glibc/ /wine-lol-glibc/.
+RUN chmod 777 -R /wine-lol-glibc
+# make our export folder
+RUN mkdir -p /glibc-builds && chmod 777 -R /glibc-builds
+# Build glibc
+RUN sudo -u nobody bash -c 'makepkg --syncdeps'
+# Copy to build folder 
+RUN cp ./wine-lol-glibc-*.pkg.tar.zst /glibc-builds/.
+
+# Second stage, building wine itself
+#   # Let's us copy glibc package from glibc-builder without rebuilding it, nice.
+FROM archlinux:latest as wine-builder
+# Dependencies for building packages with makepkg, again
+RUN pacman -Sy --noconfirm --needed sudo base-devel 
+# We need to enable lib32 and multiarch for the wine dependencies
+RUN echo '[multilib]' >> /etc/pacman.conf
+RUN echo 'Include = /etc/pacman.d/mirrorlist' >> /etc/pacman.conf
+# Dependencies for building wine-lol
+RUN pacman -Sy --noconfirm --needed attr lib32-attr fontconfig lib32-fontconfig lcms2 lib32-lcms2 libxml2 lib32-libxml2 libxcursor lib32-libxcursor libxrandr lib32-libxrandr libxdamage lib32-libxdamage libxi lib32-libxi gettext lib32-gettext freetype2 lib32-freetype2 glu lib32-glu libsm lib32-libsm gcc-libs lib32-gcc-libs libpcap lib32-libpcap desktop-file-utils
+RUN pacman -Sy --noconfirm --needed autoconf ncurses bison perl fontforge flex 'gcc>=4.5.0-2' giflib lib32-giflib libpng lib32-libpng gnutls lib32-gnutls libxinerama lib32-libxinerama libxcomposite lib32-libxcomposite libxmu lib32-libxmu libxxf86vm lib32-libxxf86vm libldap lib32-libldap mpg123 lib32-mpg123 openal lib32-openal v4l-utils lib32-v4l-utils alsa-lib lib32-alsa-lib libxcomposite lib32-libxcomposite mesa lib32-mesa mesa-libgl lib32-mesa-libgl opencl-icd-loader lib32-opencl-icd-loader libxslt lib32-libxslt libpulse lib32-libpulse libva lib32-libva gtk3 lib32-gtk3 gst-plugins-base-libs lib32-gst-plugins-base-libs vulkan-icd-loader lib32-vulkan-icd-loader sdl2 lib32-sdl2 vkd3d lib32-vkd3d sane libgphoto2 gsm ffmpeg samba opencl-headers
+RUN pacman -Sy --noconfirm --needed giflib lib32-giflib libpng lib32-libpng libldap lib32-libldap gnutls lib32-gnutls mpg123 lib32-mpg123 openal lib32-openal v4l-utils lib32-v4l-utils libpulse lib32-libpulse alsa-plugins lib32-alsa-plugins alsa-lib lib32-alsa-lib libjpeg-turbo lib32-libjpeg-turbo libxcomposite lib32-libxcomposite libxinerama lib32-libxinerama ncurses lib32-ncurses opencl-icd-loader lib32-opencl-icd-loader libxslt lib32-libxslt libva lib32-libva gtk3 lib32-gtk3 gst-plugins-base-libs lib32-gst-plugins-base-libs vulkan-icd-loader lib32-vulkan-icd-loader sdl2 lib32-sdl2 vkd3d lib32-vkd3d sane libgphoto2 gsm ffmpeg cups samba dosbox
+# Copy the custom glibc package we built earlier and install
+RUN mkdir -p /glibc-builds
+COPY --from=glibc-builder /glibc-builds/ /glibc-builds/.
+RUN pacman -U --noconfirm /glibc-builds/wine-lol-glibc-*.pkg.tar.zst
+
+# Copy source for wine
+WORKDIR /wine-lol
+ADD wine-lol/ /wine-lol/.
+RUN chmod 777 -R /wine-lol
+# Make our export folder
+RUN mkdir -p /wine-builds
+# Build wine
+RUN sudo -u nobody bash -c 'makepkg --syncdeps'
+# Copy to build folder
+RUN cp ./wine-lol-*.pkg.tar.zst /wine-builds/.
+
+# Third stage, copy the package to a separate folder (just here for caching tbh)
+FROM archlinux:latest
+RUN mkdir -p /wine-lol && chmod 777 -R wine-lol
+WORKDIR /wine-lol
+COPY --from=wine-builder /wine-builds/ /wine-lol/.
+CMD "cp" "-r" "/wine-lol/" "/wine-exports/."
+
+
+
+
+
+
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,10 +58,3 @@ WORKDIR /wine-lol
 COPY --from=wine-builder /wine-builds/ /wine-lol/.
 # Lastly, the magic command, where we export our built wine package to the mounted directory
 CMD "cp" "-r" "/wine-lol/." "/wine-exports/."
-
-
-
-
-
-
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ FROM archlinux:latest as glibc-builder
 RUN pacman -Sy --noconfirm --needed sudo base-devel 
 # Dependencies for wine-lol-glibc
 RUN pacman -Sy --noconfirm --needed git gd lib32-gcc-libs python
+# make makepkg multithreaded
+RUN echo 'MAKEFLAGS="-j$(expr $(nproc) \+ 1)"' >> /etc/makepkg.conf
 
 # copy source for glibc
 WORKDIR /wine-lol-glibc
@@ -33,6 +35,8 @@ RUN pacman -Sy --noconfirm --needed giflib lib32-giflib libpng lib32-libpng libl
 RUN mkdir -p /glibc-builds
 COPY --from=glibc-builder /glibc-builds/ /glibc-builds/.
 RUN pacman -U --noconfirm /glibc-builds/wine-lol-glibc-*.pkg.tar.zst
+# make makepkg multithreaded (again)
+RUN echo 'MAKEFLAGS="-j$(expr $(nproc) \+ 1)"' >> /etc/makepkg.conf
 
 # Copy source for wine
 WORKDIR /wine-lol

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,8 +42,10 @@ RUN chmod 777 -R /wine-lol
 RUN mkdir -p /wine-builds
 # Build wine
 RUN sudo -u nobody bash -c 'makepkg --syncdeps'
-# Copy to build folder
+# Copy wine to the build folder
 RUN cp ./wine-lol-*.pkg.tar.zst /wine-builds/.
+# Also copy glibc package?
+RUN cp /glibc-builds/wine-lol-glibc-*.pkg.tar.zst /wine-builds/.
 
 # Third stage, copy the package to a separate folder
 FROM archlinux:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,11 +45,12 @@ RUN sudo -u nobody bash -c 'makepkg --syncdeps'
 # Copy to build folder
 RUN cp ./wine-lol-*.pkg.tar.zst /wine-builds/.
 
-# Third stage, copy the package to a separate folder (just here for caching tbh)
+# Third stage, copy the package to a separate folder
 FROM archlinux:latest
 RUN mkdir -p /wine-lol && chmod 777 -R wine-lol
 WORKDIR /wine-lol
 COPY --from=wine-builder /wine-builds/ /wine-lol/.
+# Lastly, the magic command, where we export our built wine package to the mounted directory
 CMD "cp" "-r" "/wine-lol/." "/wine-exports/."
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ FROM archlinux:latest
 RUN mkdir -p /wine-lol && chmod 777 -R wine-lol
 WORKDIR /wine-lol
 COPY --from=wine-builder /wine-builds/ /wine-lol/.
-CMD "cp" "-r" "/wine-lol/" "/wine-exports/."
+CMD "cp" "-r" "/wine-lol/." "/wine-exports/."
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 Wine-LoL
 ========
+This repo tries to use a Dockerfile for compilation because VMs are hell;
+---
+Simple walkthrough on how to build and export wine:
+1. Clone the master, then, in a terminal from the root directory, build it by running
+`docker build . -t wine-lol` (this will take a while as it's actually building).
+2. Then run the image you created a moment ago with a directory from your computer mounted as `/wine-exports` so docker can export the package:
+`docker run -v /directory/to/export/to:/wine-exports wine-lol` (this should only take a moment because it's already built)
+3. `/directory/to/export/to` will have the package that was just built.
+
+Back to the rest of the forked repo
+---
 
 This repository contains build scripts to build wine-lol including the required wine-lol–glibc for Arch/Manjaro (with sync to AUR) and Debian based distributions (Ubuntu, Mint, SteamOS, ...).
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,5 @@
 Wine-LoL
 ========
-This repo tries to use a Dockerfile for compilation because VMs are hell;
----
-Simple walkthrough on how to build and export wine:
-1. Clone the master, then, in a terminal from the root directory, build it by running
-`docker build . -t wine-lol` (this will take a while as it's actually building).
-2. Then run the image you created a moment ago with a directory from your computer mounted as `/wine-exports` so docker can export the package:
-`docker run -v /directory/to/export/to:/wine-exports wine-lol` (this should only take a moment because it's already built)
-3. `/directory/to/export/to` will have the package that was just built.
-
-Back to the rest of the forked repo
----
 
 This repository contains build scripts to build wine-lol including the required wine-lol–glibc for Arch/Manjaro (with sync to AUR) and Debian based distributions (Ubuntu, Mint, SteamOS, ...).
 
@@ -36,3 +25,12 @@ Please keep in mind that the goal of this repository is **not** to keep a Wine v
 This leads us to a few points you should consider if you want to see an updated version here:
 1. I have no time to test new versions. So it's you who has to do this! This means that a **new version** can not be requested at all in an Issue but **only with a Pull Request**!
 2. You have to name **at least one improvement** in your Pull Request that this version provides for playing LoL on Linux. If a new version just works as well as the old version, then there is no need to update!
+
+Contributer notes on building using Docker
+---
+Simple steps to build with Docker on **any** distro and export wine:
+1. Clone master, then, in a terminal from the root directory, build it by running
+`docker build . -t wine-lol` (this will take a while as it's actually building).
+2. Then run the image you created a moment ago with a directory from your computer mounted as `/wine-exports` so docker can export the packages:
+`docker run -v /directory/to/export/to:/wine-exports wine-lol` (this only takes a moment because it's already built)
+3. `/directory/to/export/to` will have the package that you just built.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This leads us to a few points you should consider if you want to see an updated 
 Contributer notes on building using Docker
 ---
 Simple steps to build with Docker on **any** distro and export wine:
-1. Clone master, then, in a terminal from the root directory, build it by running
+1. Clone master, then, in a terminal from the `contrib` directory, build it by running
 `docker build . -t wine-lol` (this will take a while as it's actually building).
 2. Then run the image you created a moment ago with a directory from your computer mounted as `/wine-exports` so docker can export the packages:
 `docker run -v /directory/to/export/to:/wine-exports wine-lol` (this only takes a moment because it's already built)

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -10,7 +10,7 @@ RUN echo 'MAKEFLAGS="-j$(expr $(nproc) \+ 1)"' >> /etc/makepkg.conf
 
 # copy source for glibc
 WORKDIR /wine-lol-glibc
-ADD wine-lol-glibc/ /wine-lol-glibc/.
+ADD ../wine-lol-glibc/ /wine-lol-glibc/.
 RUN chmod 777 -R /wine-lol-glibc
 # make our export folder
 RUN mkdir -p /glibc-builds && chmod 777 -R /glibc-builds
@@ -40,7 +40,7 @@ RUN echo 'MAKEFLAGS="-j$(expr $(nproc) \+ 1)"' >> /etc/makepkg.conf
 
 # Copy source for wine
 WORKDIR /wine-lol
-ADD wine-lol/ /wine-lol/.
+ADD ../wine-lol/ /wine-lol/.
 RUN chmod 777 -R /wine-lol
 # Make our export folder
 RUN mkdir -p /wine-builds

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -1,3 +1,5 @@
+# Maintainer(s): github.com/wiryfuture
+
 # First we're gonna build glibc and then export it so we can proceed with wine
 #   # This lets us cache this process
 FROM archlinux:latest as glibc-builder


### PR DESCRIPTION
What is this?
---
This Dockerfile takes the existing PKGBUILDs and uses them to build wine-lol-glibc and then wine-lol using a freshly picked archlinux:latest container image, and then putting them into the directory you've mounted when you run the container.

Why do we need this?
---
This lets **any distro** that supports containers to build the packages; the build machines do not need to be arch based. This simplifies building the packages as only two unchanging commands are required, which have no impact on your machine whatsoever. 
This is preferable over installing the dependencies on your local machine or bootstrapping a virtual machine, as it will always be the same environment; no 'It worked on my machine' or time wasted setting up the build environment, ever!

Are there any changes in the packages themselves if they're built with this?
---
No.

Added complexity?
--- 
- One singe Dockerfile is added to the repo root, which uses preexisting PKGBUILDs to build everything for you (only one file is added to the repo which actually controls the container image). 
- Dockerfile syntax is very, very simple and can be understood by someone who has never even seen it before, and should be very easily maintainable with the comments left.
- The multi-stage building used in the image could actually save you time if any change is made to wine, but not to glibc - only wine will be rebuilt; only modified parts of the container image will be built again, everything unchanged will use cache.