### PR TITLE
Slow start fix

### DIFF
--- a/wine-lol/0005-LoL-client-slow-start-fix.patch
+++ b/wine-lol/0005-LoL-client-slow-start-fix.patch
@@ -1,0 +1,34 @@
+diff --git a/dlls/ws2_32/socket.c b/dlls/ws2_32/socket.c
+index 5089029f4b4..8731c92e2e6 100644
+--- a/dlls/ws2_32/socket.c
++++ b/dlls/ws2_32/socket.c
+@@ -4788,6 +4788,11 @@ INT WINAPI WSAIoctl(SOCKET s, DWORD code, LPVOID in_buff, DWORD in_size, LPVOID
+         break;
+     }
+ 
++    case WS_SIO_IDEAL_SEND_BACKLOG_QUERY: // LoL hack
++        if (ret_size) *ret_size = 0;
++        if (out_buff && out_size == sizeof(DWORD)) *(DWORD*)out_buff = 0;
++        return SOCKET_ERROR;
++
+     case WS_SIOCATMARK:
+     {
+         unsigned int oob = 0, atmark = 0;
+@@ -5518,6 +5523,17 @@ int WINAPI WS_select(int nfds, WS_fd_set *ws_readfds,
+     TRACE("read %p, write %p, excp %p timeout %p\n",
+           ws_readfds, ws_writefds, ws_exceptfds, ws_timeout);
+ 
++    static int is_RCS = -1; // LoL hack
++    if (is_RCS < 0) {
++        is_RCS = GetModuleHandleA(NULL) == GetModuleHandleA("RiotClientServices.exe");
++    }
++    const struct WS_timeval zero_tv = { 0, 1000 };
++    if (is_RCS && ws_readfds && ws_writefds && ws_exceptfds && ws_timeout && ws_timeout->tv_sec == 1 && ws_timeout->tv_usec == 0) {
++        if (ws_readfds->fd_count == 8 && ws_writefds->fd_count == 0  && ws_exceptfds->fd_count == 1) {
++            ws_timeout = &zero_tv;
++        }
++    }
++
+     if (!(pollfds = fd_sets_to_poll( ws_readfds, ws_writefds, ws_exceptfds, &count )))
+         return SOCKET_ERROR;
+ 

--- a/wine-lol/PKGBUILD
+++ b/wine-lol/PKGBUILD
@@ -25,6 +25,7 @@ source=("wine-tkg-5.18.tar.gz::https://github.com/Tk-Glitch/wine-tkg/archive/e37
         0001-ntdll-Stub-NtQueryInformationThread-ThreadHideFromDe.patch
         0001-Revert-winex11.drv-Update-_NET_WM_STATE-before-resiz.patch
         0001-Fix-ldap_connect-name-conflict.patch
+        0005-LoL-client-slow-start-fix.patch
        )
 sha512sums=('85ea388e711b2a659b37233bcfd423d6bed3a56190d6cff3a9465eb8c0590cbc73b69479ec25749d43be9de7d8a37833e1c5c5f908d8e3c69f131ffa79dcbde3'
             '6e54ece7ec7022b3c9d94ad64bdf1017338da16c618966e8baf398e6f18f80f7b0576edf1d1da47ed77b96d577e4cbb2bb0156b0b11c183a0accf22654b0a2bb'
@@ -33,7 +34,8 @@ sha512sums=('85ea388e711b2a659b37233bcfd423d6bed3a56190d6cff3a9465eb8c0590cbc73b
             '78680db42591fc882c50c4fc5156a1d3db915d71b8982b42b2affc6701d55bc5dacfd2d7a435a7b1424f9480b1e2db332321d9b4dae7122a3a0ad1efdcbe1d59'
             '68c027c748faf1ea86c4b01f2decadb3240d1e98f1f16a9fc6f6a841bb5240efc91237e77aedd188c450b6f47e1ca89620ef924ec44e3f0bc2c9097361c1ac08'
             'ff6ea107598bd681bb5534d977e2f40fe8104bcf53148284fdd2be14f67db1dfe6d8176ff8200fc982ab3902c28e4186876c4d1870fd7362d98e8b3b6d8efe31'
-            '9be470762bfa4bf098e919bf94210103e1e9147693e74bfbc88fa539b3d1c8bd2da017005380dbe21ace39cc4fa949e923b3682cb9265d61bbd0e2f988562dbd')
+            '9be470762bfa4bf098e919bf94210103e1e9147693e74bfbc88fa539b3d1c8bd2da017005380dbe21ace39cc4fa949e923b3682cb9265d61bbd0e2f988562dbd'
+            '4d4746f00dc2ab18a221201404d875db789e875957d3587d80a73059a48b697318ebd8d21d2fd764d7665d7087283220e562104381421a559fc2eb72bafbf524')
 
 pkgdesc="A compatibility layer for running Windows programs - Wine Tk-Glitch with League Of Legends fixes"
 url="https://github.com/M-Reimer/wine-lol"
@@ -153,6 +155,9 @@ prepare() {
 
   # Fix ldap_connect
   patch -d "$srcdir/$pkgname" -p1 -i "$srcdir/0001-Fix-ldap_connect-name-conflict.patch"
+  
+  # Fix slow start
+  patch -d "$srcdir/$pkgname" -p1 -i "$srcdir/0005-LoL-client-slow-start-fix.patch"
 }
 
 build() {


### PR DESCRIPTION
Added this patch:
https://gist.github.com/moonshadow565/5498ae6ca9d7e2a0913f7f1be30f2a60/66794fa0017544dde4655b9ee0adb30b036c8930#file-0005-lol-client-slow-start-fix-patch

For the fast start to work you have to change the executable to RiotClientServices.exe and REMOVE the launch arguments (--launch-product=league_of_legends --launch-patchline=live). This means you have to select League of Legends each time in the Riot Client but otherwise the fast start does not work (this is also needed with the most recent Lutris-GE-7.0-2-LoL).

If you start the game via LeagueClient.exe or with launch arguments the Launcher will just time out like it does without the LauncherHelper.

You should also remove the launcherhelper.sh from the pre-launch scripts if you use Lutris since its not needed anymore.
Client will start in a few seconds with this patch.
I tested this on 2 machines (both Manjaro).