### PR TITLE
Update/Revert back to 7.0-GE-5-LoL

### DIFF
--- a/wine-lol-bin/.SRCINFO
+++ b/wine-lol-bin/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = wine-lol-bin
 	pkgdesc = A compatibility layer for running Windows programs - GloriousEggroll custom wine build for running League of Legends
-	pkgver = 7.14_1
+	pkgver = 7.0_5
 	pkgrel = 1
 	url = https://github.com/GloriousEggroll/wine-ge-custom
 	install = wine.install
@@ -91,9 +91,9 @@ pkgbase = wine-lol-bin
 	options = staticlibs
 	options = !lto
 	options = !strip
-	source = https://github.com/GloriousEggroll/wine-ge-custom/releases/download/7.14-GE-1-LoL/wine-lutris-ge-lol-7.14-1-x86_64.tar.xz
+	source = https://github.com/GloriousEggroll/wine-ge-custom/releases/download/7.0-GE-5-LoL/wine-lutris-ge-lol-7.0-5-x86_64.tar.xz
 	source = 30-win32-aliases.conf
-	sha512sums = 5c3241aea22e679b7faac7dd29a2c591c98a93bc48ed894fe6e09074bf90d322421421c696ea6cf04db6730a68bc5fe0f15cc3ccd80d0c0b95143b3d00e2a91b
+	sha512sums = 5046c0b498c28204625502dae070d7ed19cd87491ddf5815ed104a92d0d9404df366ff634971c7416e45033b373a3a1e13951f46167937bed294d1dbb61d0dd4
 	sha512sums = 6e54ece7ec7022b3c9d94ad64bdf1017338da16c618966e8baf398e6f18f80f7b0576edf1d1da47ed77b96d577e4cbb2bb0156b0b11c183a0accf22654b0a2bb
 
 pkgname = wine-lol-bin

--- a/wine-lol-bin/PKGBUILD
+++ b/wine-lol-bin/PKGBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Manuel Reimer <mail+wine@m-reimer.de>
 
 pkgname=wine-lol-bin
-pkgver=7.14_1
+pkgver=7.0_5
 pkgrel=1
 
 _ver=${pkgver%_*}
@@ -10,7 +10,7 @@ _rev=${pkgver#*_}
 
 source=(https://github.com/GloriousEggroll/wine-ge-custom/releases/download/$_ver-GE-$_rev-LoL/wine-lutris-ge-lol-$_ver-$_rev-x86_64.tar.xz
         30-win32-aliases.conf)
-sha512sums=('5c3241aea22e679b7faac7dd29a2c591c98a93bc48ed894fe6e09074bf90d322421421c696ea6cf04db6730a68bc5fe0f15cc3ccd80d0c0b95143b3d00e2a91b'
+sha512sums=('5046c0b498c28204625502dae070d7ed19cd87491ddf5815ed104a92d0d9404df366ff634971c7416e45033b373a3a1e13951f46167937bed294d1dbb61d0dd4'
             '6e54ece7ec7022b3c9d94ad64bdf1017338da16c618966e8baf398e6f18f80f7b0576edf1d1da47ed77b96d577e4cbb2bb0156b0b11c183a0accf22654b0a2bb')
 
 pkgdesc="A compatibility layer for running Windows programs - GloriousEggroll custom wine build for running League of Legends"

--- a/wine-lol/.SRCINFO
+++ b/wine-lol/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = wine-lol
 	pkgdesc = A compatibility layer for running Windows programs - GloriousEggroll custom wine build for running League of Legends
-	pkgver = 7.14
+	pkgver = 7.0.5
 	pkgrel = 1
 	url = https://github.com/GloriousEggroll/wine
 	install = wine.install
@@ -150,9 +150,11 @@ pkgbase = wine-lol
 	optdepends = dosbox
 	options = staticlibs
 	options = !lto
-	source = wine-lol-7.14.tar.gz::https://github.com/GloriousEggroll/wine/archive/08c12b497c8f4ca2f6dc4f1c0536b087dce25780.tar.gz
+	source = wine-lol-7.0.5.tar.gz::https://github.com/GloriousEggroll/wine/archive/6703dc23fbb57a32261864bf547d16ba508351fb.tar.gz
 	source = 30-win32-aliases.conf
-	sha512sums = 3689b907757aff8901f0d27d5cdbbfc230862e711b4687bb16dfa619d9a2ab30cb4565dc75b75a8d88f24a4653085d0504ca17922390bd5b5acd00031a11e156
+	source = futex.patch
+	sha512sums = 8ffa445333f6e677f9df78c93fa05a3634c30f11071f5367f5c36cf143410410a0d3570eb8e4fe50959293c5b9c695498d3db1ca5c27b7d91665697eb1365d23
 	sha512sums = 6e54ece7ec7022b3c9d94ad64bdf1017338da16c618966e8baf398e6f18f80f7b0576edf1d1da47ed77b96d577e4cbb2bb0156b0b11c183a0accf22654b0a2bb
+	sha512sums = 02c650aa559a33b7f2bc35deb2946b28473428e1c166895f0e60d3ab766475db172f974e24860850d1575a843056b673fb1dfe1390204d528b1323cc65d0efce
 
 pkgname = wine-lol

--- a/wine-lol/PKGBUILD
+++ b/wine-lol/PKGBUILD
@@ -7,17 +7,19 @@
 # Contributor: Giovanni Scafora <giovanni@archlinux.org>
 
 pkgname=wine-lol
-pkgver=7.14
+pkgver=7.0.5
 pkgrel=1
 
 # Be sure to use commits from a "ge-lol-XXX" branch here
-_gitver=08c12b497c8f4ca2f6dc4f1c0536b087dce25780
+_gitver=6703dc23fbb57a32261864bf547d16ba508351fb
 
 # Using VCS source here (git+https...) takes forever so get a snapshot instead
 source=($pkgname-$pkgver.tar.gz::https://github.com/GloriousEggroll/wine/archive/$_gitver.tar.gz
-        30-win32-aliases.conf)
-sha512sums=('3689b907757aff8901f0d27d5cdbbfc230862e711b4687bb16dfa619d9a2ab30cb4565dc75b75a8d88f24a4653085d0504ca17922390bd5b5acd00031a11e156'
-            '6e54ece7ec7022b3c9d94ad64bdf1017338da16c618966e8baf398e6f18f80f7b0576edf1d1da47ed77b96d577e4cbb2bb0156b0b11c183a0accf22654b0a2bb')
+        30-win32-aliases.conf
+        futex.patch)
+sha512sums=('8ffa445333f6e677f9df78c93fa05a3634c30f11071f5367f5c36cf143410410a0d3570eb8e4fe50959293c5b9c695498d3db1ca5c27b7d91665697eb1365d23'
+            '6e54ece7ec7022b3c9d94ad64bdf1017338da16c618966e8baf398e6f18f80f7b0576edf1d1da47ed77b96d577e4cbb2bb0156b0b11c183a0accf22654b0a2bb'
+            '02c650aa559a33b7f2bc35deb2946b28473428e1c166895f0e60d3ab766475db172f974e24860850d1575a843056b673fb1dfe1390204d528b1323cc65d0efce')
 
 pkgdesc="A compatibility layer for running Windows programs - GloriousEggroll custom wine build for running League of Legends"
 url="https://github.com/GloriousEggroll/wine"
@@ -113,6 +115,9 @@ install=wine.install
 prepare() {
   # Allow ccache to work
   mv wine-$_gitver $pkgname
+
+  # Fix futex compilation error
+  patch -d $pkgname -Np1 -i "$srcdir"/futex.patch
 
   # Fix opencl header path
   sed 's|OpenCL/opencl.h|CL/opencl.h|g' -i $pkgname/configure*

--- a/wine-lol/futex.patch
+++ b/wine-lol/futex.patch
@@ -1,0 +1,11 @@
+diff --color -rupN a/dlls/ntdll/unix/fsync.c b/dlls/ntdll/unix/fsync.c
+--- a/dlls/ntdll/unix/fsync.c
++++ b/dlls/ntdll/unix/fsync.c
+@@ -51,6 +51,7 @@
+
+ #include "unix_private.h"
+ #include "fsync.h"
++#include <linux/futex.h>
+
+ WINE_DEFAULT_DEBUG_CHANNEL(fsync);
+


### PR DESCRIPTION
Fix the [after-match client hanging issue](https://github.com/kyechou/leagueoflegends/issues/57).
Changelog: https://github.com/GloriousEggroll/wine-ge-custom/releases/tag/7.0-GE-5-LoL