### PR TITLE
Update wine-lol(-bin) (8_27)

### DIFF
--- a/wine-lol-bin/.SRCINFO
+++ b/wine-lol-bin/.SRCINFO
@@ -1,8 +1,8 @@
 pkgbase = wine-lol-bin
 	pkgdesc = A compatibility layer for running Windows programs - GloriousEggroll custom wine build for running League of Legends
-	pkgver = p8_12
+	pkgver = 8_27
 	pkgrel = 1
-	epoch = 2
+	epoch = 3
 	url = https://github.com/GloriousEggroll/wine-ge-custom
 	install = wine.install
 	arch = x86_64
@@ -65,9 +65,9 @@ pkgbase = wine-lol-bin
 	options = staticlibs
 	options = !lto
 	options = !strip
-	source = https://github.com/GloriousEggroll/wine-ge-custom/releases/download/GE-LOL-p8-12/wine-lutris-ge-lol-p8-12-x86_64.tar.xz
+	source = https://github.com/GloriousEggroll/wine-ge-custom/releases/download/GE-Proton8-27-LoL/wine-lutris-GE-Proton8-27-LoL-x86_64.tar.xz
 	source = 30-win32-aliases.conf
-	sha512sums = 6e4c9a79d6d8255c7fe2de2081d39c4dace45fb27a21ddae8eb3789a191bde85bedbfee2e6a8bc227c4c578912dbf93ec860de649bed1b84038c3261b3a3af9c
+	sha512sums = 3d83d5b2658e0e09ce511113439b497f4276e9c4a3260309dbda46599b6b7aaa95b0f139863bac29cd5f8ebaa3600d56f3a4b6479833acf665040d2121346d48
 	sha512sums = 6e54ece7ec7022b3c9d94ad64bdf1017338da16c618966e8baf398e6f18f80f7b0576edf1d1da47ed77b96d577e4cbb2bb0156b0b11c183a0accf22654b0a2bb
 
 pkgname = wine-lol-bin

--- a/wine-lol-bin/PKGBUILD
+++ b/wine-lol-bin/PKGBUILD
@@ -2,16 +2,16 @@
 # Maintainer: Manuel Reimer <mail+wine@m-reimer.de>
 
 pkgname=wine-lol-bin
-pkgver=p8_12
+pkgver=8_27
 pkgrel=1
-epoch=2
+epoch=3
 
 _ver=${pkgver%_*}
 _rev=${pkgver#*_}
 
-source=("https://github.com/GloriousEggroll/wine-ge-custom/releases/download/GE-LOL-$_ver-$_rev/wine-lutris-ge-lol-$_ver-$_rev-x86_64.tar.xz"
+source=("https://github.com/GloriousEggroll/wine-ge-custom/releases/download/GE-Proton$_ver-$_rev-LoL/wine-lutris-GE-Proton$_ver-$_rev-LoL-x86_64.tar.xz"
         30-win32-aliases.conf)
-sha512sums=('6e4c9a79d6d8255c7fe2de2081d39c4dace45fb27a21ddae8eb3789a191bde85bedbfee2e6a8bc227c4c578912dbf93ec860de649bed1b84038c3261b3a3af9c'
+sha512sums=('3d83d5b2658e0e09ce511113439b497f4276e9c4a3260309dbda46599b6b7aaa95b0f139863bac29cd5f8ebaa3600d56f3a4b6479833acf665040d2121346d48'
             '6e54ece7ec7022b3c9d94ad64bdf1017338da16c618966e8baf398e6f18f80f7b0576edf1d1da47ed77b96d577e4cbb2bb0156b0b11c183a0accf22654b0a2bb')
 
 pkgdesc="A compatibility layer for running Windows programs - GloriousEggroll custom wine build for running League of Legends"
@@ -63,7 +63,7 @@ install=wine.install
 
 package() {
   mkdir -p "$pkgdir/opt/wine-lol"
-  cp -r "$srcdir/lutris-ge-lol-$_ver-$_rev-x86_64/." "$pkgdir/opt/wine-lol/"
+  cp -r "$srcdir/lutris-GE-Proton$_ver-$_rev-LoL-x86_64/." "$pkgdir/opt/wine-lol/"
 
   # Font aliasing settings for Win32 applications
   install -d "$pkgdir"/etc/fonts/conf.{avail,default}

--- a/wine-lol/.SRCINFO
+++ b/wine-lol/.SRCINFO
@@ -1,8 +1,8 @@
 pkgbase = wine-lol
 	pkgdesc = A compatibility layer for running Windows programs - GloriousEggroll custom wine build for running League of Legends
-	pkgver = p8_12
+	pkgver = 8_27
 	pkgrel = 1
-	epoch = 2
+	epoch = 3
 	url = https://github.com/GloriousEggroll/wine-ge-custom
 	install = wine.install
 	arch = x86_64
@@ -108,9 +108,9 @@ pkgbase = wine-lol
 	optdepends = dosbox
 	options = staticlibs
 	options = !lto
-	source = wine-lol-p8_12.tar.gz::https://github.com/GloriousEggroll/proton-wine/archive/0926dc8d033e4d7b32aa745bcfd2ec72adee089e.tar.gz
+	source = wine-lol-8_27.tar.gz::https://github.com/GloriousEggroll/proton-wine/archive/9870f7b23d1dac43324915ac54d784812a8f8e54.tar.gz
 	source = 30-win32-aliases.conf
-	sha512sums = 0bb59bd7497cec5aeb325189abf9b191bcccbd9dc9ee45c9090b429da9d62b9aaa35aedb4a1bfde3d69bd2b665ad75f4f623c089689891db4652ce8c58ba64f9
+	sha512sums = cb82f8407bfed1728787c83d8023f126c7679b2ff82c5a1ce8049a170126fc4e1f06f03d45a6ab62cda1a1bc724b2c7f073f2f25d1e12cbba65be2035295abda
 	sha512sums = 6e54ece7ec7022b3c9d94ad64bdf1017338da16c618966e8baf398e6f18f80f7b0576edf1d1da47ed77b96d577e4cbb2bb0156b0b11c183a0accf22654b0a2bb
 
 pkgname = wine-lol

--- a/wine-lol/PKGBUILD
+++ b/wine-lol/PKGBUILD
@@ -7,17 +7,17 @@
 # Contributor: Giovanni Scafora <giovanni@archlinux.org>
 
 pkgname=wine-lol
-pkgver=p8_12
+pkgver=8_27
 pkgrel=1
-epoch=2
+epoch=3
 
 # Be sure to use commits from a "lol-pX-XX" branch here
-_gitver=0926dc8d033e4d7b32aa745bcfd2ec72adee089e
+_gitver=9870f7b23d1dac43324915ac54d784812a8f8e54
 
 # Using VCS source here (git+https...) takes forever so get a snapshot instead
 source=("$pkgname-$pkgver.tar.gz::https://github.com/GloriousEggroll/proton-wine/archive/$_gitver.tar.gz"
         30-win32-aliases.conf)
-sha512sums=('0bb59bd7497cec5aeb325189abf9b191bcccbd9dc9ee45c9090b429da9d62b9aaa35aedb4a1bfde3d69bd2b665ad75f4f623c089689891db4652ce8c58ba64f9'
+sha512sums=('cb82f8407bfed1728787c83d8023f126c7679b2ff82c5a1ce8049a170126fc4e1f06f03d45a6ab62cda1a1bc724b2c7f073f2f25d1e12cbba65be2035295abda'
             '6e54ece7ec7022b3c9d94ad64bdf1017338da16c618966e8baf398e6f18f80f7b0576edf1d1da47ed77b96d577e4cbb2bb0156b0b11c183a0accf22654b0a2bb')
 
 pkgdesc="A compatibility layer for running Windows programs - GloriousEggroll custom wine build for running League of Legends"


### PR DESCRIPTION
Update to the latest [GE-Proton8-27-LoL](https://github.com/GloriousEggroll/wine-ge-custom/releases/tag/GE-Proton8-27-LoL), which should fix the issues and bans with the recent LoL patches.

(Note: I have not tested it myself by playing a match.)